### PR TITLE
docs(repository): Sync repository metadata

### DIFF
--- a/.repository/index.json
+++ b/.repository/index.json
@@ -13,6 +13,7 @@
     "ddpg"
   ],
   "languages": [
+    "Dockerfile",
     "Jupyter Notebook",
     "Python",
     "Shell"


### PR DESCRIPTION
Sync the repository metadata in code, from the github data.

Standardize the github data on topics, taglines and other properties into a repository definition file. For now this can be json instead of YAML, as that is easier to get started with. Later work can be done to convert this to a YAML format.